### PR TITLE
Add oauth_verifier to authorization header

### DIFF
--- a/src/Request/ProtocolParameter.php
+++ b/src/Request/ProtocolParameter.php
@@ -124,6 +124,7 @@ class ProtocolParameter implements ProtocolParameterInterface
         $parameters = $this->getBase();
 
         $parameters['oauth_token'] = $temporaryCredentials->getIdentifier();
+        $parameters['oauth_verifier'] = $verificationCode;
 
         $requestOptions = [
             'form_params' => ['oauth_verifier' => $verificationCode],


### PR DESCRIPTION
Hey,

thanks for sharing this packages. This took so much work off me to create the auth flow with an external api.
I struggled with creating the access token from the temporary credentials and oauth_verifier. This package is sending the verifier as form data. But apparently some services need it to be in the Authorization header as well (in my case it was [ImmoScout24](https://api.immobilienscout24.de/api-docs)).

This is also stated here:
- https://tools.ietf.org/html/rfc5849#section-2.3
- https://oauth1.wp-api.org/docs/basics/Auth-Flow.html#token-exchange