### PR TITLE
Declare compatibility with Guzzle v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
     },
     "require": {
         "php": ">=5.6.4",
-        "guzzlehttp/guzzle": "~6.3",
-        "guzzlehttp/psr7": "^1.4.2",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
+        "guzzlehttp/psr7": "^1.4.2|^2.0",
         "paragonie/random_compat": "~1.4|~2.0",
         "psr/http-message": "^1.0"
     },


### PR DESCRIPTION
I checked all the (few) places where oauth1 calls Guzzle APIs and they should still work. Also none of the items in the [upgrading guide](https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70) seem applicable. The [native function calls](https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#native-functions-calls) change and the [booleans change](https://github.com/guzzle/psr7/blob/2.0.0/CHANGELOG.md#200beta-1---2021-03-21) in guzzle/psr7 might be breaking for some users of oauth1, but I'm not sure if oauth1 needs a major release due to this, as users are free to keep using the old Guzzle versions.